### PR TITLE
Expand doc and add test mode flag

### DIFF
--- a/Astral Codex Ten/ebook.sh
+++ b/Astral Codex Ten/ebook.sh
@@ -1,6 +1,14 @@
 #!/bin/bash
 cp  posts.json /tmp/posts.json
 
+# add 'test' as a first argument to download only a few articles
+if [ "$1" = "test" ]
+then
+        TEST="--test"
+else
+        TEST=""
+fi
+
 ebook-convert "Astral Codex Ten.recipe" .mobi \
         --authors="Scott Alexander" \
         --title="Astral Codex Ten" \
@@ -8,4 +16,4 @@ ebook-convert "Astral Codex Ten.recipe" .mobi \
         --cover="images/cover.jpg" \
         --output-profile=kindle_pw3 \
         --mobi-file-type=new \
-        -vv --test
+        -vv $TEST

--- a/Readme.md
+++ b/Readme.md
@@ -31,10 +31,10 @@ cd Slate-Star-Codex
 # enter the folder for one of the blogs
 cd Astral\ Codex\ Ten/
 
-# do a test run: this should download 4 articles into an epub. Check the epub works
+# do a test run: this should download 4 articles into an ebook. Check the ebook works
 ./ebooks.sh test
 
-# do a full run: this will download all articles and build the epub for the whole blog
+# do a full run: this will download all articles and build the ebook for the whole blog
 ./ebook.sh
 ```
 

--- a/Readme.md
+++ b/Readme.md
@@ -19,6 +19,25 @@ There are over 1500 blogs in the archives，I've filtered out a lot with the fol
 (Links for)|(Links\s*\d+\/\d+)|(Open Thread)|(OT\s*\d+)|(SSC)|(Meetup)|(Thread\s*\d+)|(Contest)|(\d+ Predictions)|(Predictions for)|(Hidden Test Post)|(Take.*Survey)|(Adversarial Collaboration)|(Vote for)
 ```
 
+## How to use
+
+To download the blogs and build the ebooks, you can
+
+```bash
+# clone the repo
+git clone https://github.com/evmn/Slate-Star-Codex.git
+cd Slate-Star-Codex
+
+# enter the folder for one of the blogs
+cd Astral\ Codex\ Ten/
+
+# do a test run: this should download 4 articles into an epub. Check the epub works
+./ebooks.sh test
+
+# do a full run: this will download all articles and build the epub for the whole blog
+./ebook.sh
+```
+
 ## Astral Codex Ten
 
 The author start a new blog in substack with a new name [Astral Codex Ten](https://astralcodexten.substack.com/) after a conflict with NYT in 2020.

--- a/Slate Star Codex/ebook.sh
+++ b/Slate Star Codex/ebook.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
 
+# add 'test' as a first argument to download only a few articles
+if [ "$1" = "test" ]
+then
+        TEST="--test"
+else
+        TEST=""
+fi
+
 ebook-convert "ssc.recipe" .mobi \
         --authors="Scott Alexander" \
         --title="Slate Star Codex" \
@@ -9,4 +17,4 @@ ebook-convert "ssc.recipe" .mobi \
         --cover="images/cover.jpg" \
         --output-profile=kindle_pw3 \
         --mobi-file-type=new \
-        -vv --test
+        -vv $TEST


### PR DESCRIPTION
Thanks a lot for this repo, this is exactly what I was looking for.

Since I wasn't familiar with Calibre recipes it took me a while to understand what was going on, and I almost gave up thinking it was only downloading a few articles because of a bug and not because of the `--test` flag.

So here's a suggestion with a little more doc and a tentative explicit flag to pass to `ebook.sh` (probably not very pretty as I'm not used to writing bash scripts, but it does the job on my machine...)

Thank you for publishing your code!